### PR TITLE
Navigation updates

### DIFF
--- a/src/Components/SurveyComponent.js
+++ b/src/Components/SurveyComponent.js
@@ -27,13 +27,16 @@ function SurveyComponent() {
 
     return (
         <div>
-            <Survey.Survey
-                json={SURVEY_DATA}
-                css={myCss}
-                onValueChanged={persistDataToLocalStorage}
-                onComplete={onComplete}
-            />
-            <Outcome type={outcome} />
+            {!outcome ? (
+                <Survey.Survey
+                    json={SURVEY_DATA}
+                    css={myCss}
+                    onValueChanged={persistDataToLocalStorage}
+                    onComplete={onComplete}
+                />
+            ) : (
+                <Outcome type={outcome} />
+            )}
         </div>
     );
 }

--- a/src/Components/SurveyComponent.js
+++ b/src/Components/SurveyComponent.js
@@ -15,25 +15,55 @@ const myCss = {
 
 function SurveyComponent() {
     const [surveyData, setSurveyData] = useLocalStorage('surveyData', null);
+    const [outcome, setOutcome] = useState('');
 
-    function sendDataToServer(survey) {
-        console.log(survey);
+    function onComplete(survey) {
+        setOutcome(survey.data.outcome);
     }
 
     function persistDataToLocalStorage(survey) {
         setSurveyData(survey.data);
     }
 
-    useEffect(() => {});
-
     return (
-        <Survey.Survey
-            json={SURVEY_DATA}
-            css={myCss}
-            onValueChanged={persistDataToLocalStorage}
-            onComplete={sendDataToServer}
-        />
+        <div>
+            <Survey.Survey
+                json={SURVEY_DATA}
+                css={myCss}
+                onValueChanged={persistDataToLocalStorage}
+                onComplete={onComplete}
+            />
+            <Outcome type={outcome} />
+        </div>
     );
 }
+
+const Outcome = ({ type }) => {
+    switch (type) {
+        case 'eligible':
+            return (
+                <div>
+                    <h2>You are eligible!</h2>
+                    <div>blah blah blah</div>
+                </div>
+            );
+        case 'needInfo':
+            return (
+                <div>
+                    <h2>Need more info</h2>
+                    <div>go here ask this ....</div>
+                </div>
+            );
+        case 'ineligible':
+            return (
+                <div>
+                    <h2>Sorry not eligible</h2>
+                    <div>here are resources</div>
+                </div>
+            );
+        default:
+            return null;
+    }
+};
 
 export default SurveyComponent;

--- a/src/data/survey.js
+++ b/src/data/survey.js
@@ -1,5 +1,11 @@
 const SURVEY_DATA = {
     title: 'Tell us some more about your case.',
+    // triggers: [
+    //     {
+    //         type: 'complete',
+    //         expression: "{coloradoArrest} = 'No'"
+    //     }
+    // ],
     pages: [
         {
             name: 'preliminaryQuestions',
@@ -8,16 +14,12 @@ const SURVEY_DATA = {
                     type: 'radiogroup',
                     choices: ['Yes', 'No'],
                     isRequired: true,
-                    name: 'skipToEnd',
-                    title: 'Would you like to skip to the end?',
-                },
-                {
-                    type: 'radiogroup',
-                    choices: ['Yes', 'No'],
-                    isRequired: true,
                     name: 'coloradoArrest',
                     title: 'Did your arrest or charge take place in Colorado?',
-                    visibleIf: "{skipToEnd} = 'No'",
+                    // resultMap: {
+                    //     'Yes': 'Eligible',
+                    //     'No': 'Ineligible'
+                    // }
                 },
                 {
                     type: 'radiogroup',
@@ -40,7 +42,7 @@ const SURVEY_DATA = {
         {
             name: 'sealingArrestsAndCharges',
             visibleIf:
-                "{skipToEnd} = 'No' and {coloradoArrest} = 'Yes' and {over18} = 'Yes' and {federalCase} = 'No'",
+                "{coloradoArrest} = 'Yes' and {over18} = 'Yes' and {federalCase} = 'No'",
             questions: [
                 {
                     type: 'radiogroup',
@@ -68,9 +70,8 @@ const SURVEY_DATA = {
                     ],
                     isRequired: true,
                     name: 'chargeToSeal',
-                    title: 'What charge are you looking to seal?',
-                    visibleIf:
-                        "({chargeDismissedOrAcquitted} = 'No' or {chargeDismissedOrAcquitted} = 'Yes') and {sealingArrestRecordOnly} = 'No'",
+                    title: 'What conviction are you looking to seal?',
+                    visibleIf: "{chargeDismissedOrAcquitted} = 'No'",
                 },
             ],
         },
@@ -97,7 +98,7 @@ const SURVEY_DATA = {
                     isRequired: true,
                     name: 'enoughTimePassed',
                     title:
-                        'What is the month & year of your conviction or release from supervision, whichever is later?',
+                        'In most cases, a certain period of time must go by from the date of conviction, or the final date of completing a sentence, before you can apply to seal your record. What is the month & year you completed your sentencing/supervision?',
                     visibleIf: "{completedSentencing} = 'Yes'",
                 },
                 {
@@ -113,17 +114,26 @@ const SURVEY_DATA = {
                     type: 'radiogroup',
                     choices: ['Yes', 'No', 'Not Sure'],
                     isRequired: true,
+                    name: 'attemptedToSeal',
+                    title:
+                        'Have you attempted to seal your record for this conviction within the past 12 months?',
+                    visibleIf: "{paidRestitutionAndFees} = 'Yes'",
+                },
+                {
+                    type: 'radiogroup',
+                    choices: ['Yes', 'No', 'Not Sure'],
+                    isRequired: true,
                     name: 'anyNewOffense',
                     title:
                         'Have you been convicted of or charged with another offense after the conviction you are trying to seal?',
-                    visibleIf: "{paidRestitutionAndFees} = 'Yes'",
+                    visibleIf: "{attemptedToSeal} = 'No'",
                 },
             ],
         },
         {
             name: 'ineligibleStatus',
             visibleIf:
-                "{coloradoArrest} = 'No' or {over18} = 'No' or {federalCase} = 'Yes' or {chargeToSeal} = 'Ineligible Charge Type' or {completedSentencing} = 'No' or {enoughTimePassed} = 'Not Enough Time Has Passed' or {paidRestitutionAndFees} = 'No'",
+                "{coloradoArrest} = 'No' or {over18} = 'No' or {federalCase} = 'Yes' or {chargeToSeal} = 'Ineligible Charge Type' or {completedSentencing} = 'No' or {enoughTimePassed} = 'Not Enough Time Has Passed' or {paidRestitutionAndFees} = 'No' or {attemptedToSeal} = 'Yes'",
             questions: [
                 {
                     type: 'comment',
@@ -156,18 +166,6 @@ const SURVEY_DATA = {
                     name: 'about',
                     title:
                         'Given your responses, your case is eligible for the services provided by Expunge Colorado. Please provide your contact information in the space below',
-                },
-            ],
-        },
-        {
-            name: 'skipToEnd',
-            visibleIf: "{skipToEnd} = 'Yes'",
-            questions: [
-                {
-                    type: 'comment',
-                    name: 'about',
-                    title:
-                        'Please tell us about your main requirements for Survey library',
                 },
             ],
         },

--- a/src/data/survey.js
+++ b/src/data/survey.js
@@ -1,11 +1,29 @@
 const SURVEY_DATA = {
     title: 'Tell us some more about your case.',
-    // triggers: [
-    //     {
-    //         type: 'complete',
-    //         expression: "{coloradoArrest} = 'No'"
-    //     }
-    // ],
+    triggers: [
+        {
+            type: 'setvalue',
+            expression:
+                "{coloradoArrest} = 'No' or {over18} = 'No' or {federalCase} = 'Yes' or {chargeToSeal} = 'Ineligible Charge Type' or {completedSentencing} = 'No' or {enoughTimePassed} = 'Not Enough Time Has Passed' or {paidRestitutionAndFees} = 'No' or {attemptedToSeal} = 'Yes'",
+            setToName: 'outcome',
+            setValue: 'ineligible',
+        },
+        {
+            type: 'setvalue',
+            expression:
+                "{sealingArrestRecordOnly} = 'Yes' or {chargeDismissedOrAcquitted} = 'Yes' or {anyNewOffense} = 'No'",
+
+            setToName: 'outcome',
+            setValue: 'eligible',
+        },
+        {
+            type: 'setvalue',
+            expression:
+                "{federalCase} = 'Not Sure' or {chargeToSeal} = 'Not Sure' or {completedSentencing} = 'Not Sure' or {enoughTimePassed} = 'Not Sure' or {chargeDismissedOrAcquitted} = 'Not Sure' or {paidRestitutionAndFees} = 'Not Sure' or {anyNewOffense} = 'Yes' or {anyNewOffense} = 'Not Sure'",
+            setToName: 'outcome',
+            setValue: 'needInfo',
+        },
+    ],
     pages: [
         {
             name: 'preliminaryQuestions',
@@ -16,10 +34,6 @@ const SURVEY_DATA = {
                     isRequired: true,
                     name: 'coloradoArrest',
                     title: 'Did your arrest or charge take place in Colorado?',
-                    // resultMap: {
-                    //     'Yes': 'Eligible',
-                    //     'No': 'Ineligible'
-                    // }
                 },
                 {
                     type: 'radiogroup',
@@ -130,56 +144,7 @@ const SURVEY_DATA = {
                 },
             ],
         },
-        {
-            name: 'ineligibleStatus',
-            visibleIf:
-                "{coloradoArrest} = 'No' or {over18} = 'No' or {federalCase} = 'Yes' or {chargeToSeal} = 'Ineligible Charge Type' or {completedSentencing} = 'No' or {enoughTimePassed} = 'Not Enough Time Has Passed' or {paidRestitutionAndFees} = 'No' or {attemptedToSeal} = 'Yes'",
-            questions: [
-                {
-                    type: 'comment',
-                    name: 'about',
-                    title:
-                        'Given your responses, your case is not eligible for the services provided by Expunge Colorado.',
-                },
-            ],
-        },
-        {
-            name: 'additionalInfoRequired',
-            visibleIf:
-                "{federalCase} = 'Not Sure' or {chargeToSeal} = 'Not Sure' or {completedSentencing} = 'Not Sure' or {enoughTimePassed} = 'Not Sure' or {chargeDismissedOrAcquitted} = 'Not Sure' or {paidRestitutionAndFees} = 'Not Sure' or {anyNewOffense} = 'Yes' or {anyNewOffense} = 'Not Sure'",
-            questions: [
-                {
-                    type: 'comment',
-                    name: 'about',
-                    title:
-                        'Given your responses, additional information will need to be collected to determine elibility. Please provide your contact information in the space below',
-                },
-            ],
-        },
-        {
-            name: 'eligibleStatus',
-            visibleIf:
-                "{sealingArrestRecordOnly} = 'Yes' or {chargeDismissedOrAcquitted} = 'Yes' or {anyNewOffense} = 'No'",
-            questions: [
-                {
-                    type: 'comment',
-                    name: 'about',
-                    title:
-                        'Given your responses, your case is eligible for the services provided by Expunge Colorado. Please provide your contact information in the space below',
-                },
-            ],
-        },
     ],
 };
-
-// {
-//     type: 'checkbox',
-//     choices: ['Bootstrap', 'Foundation'],
-//     hasOther: true,
-//     isRequired: true,
-//     name: 'framework',
-//     title: 'What front-end framework do you use?',
-//     visibleIf: "{frameworkUsing} = 'Yes'",
-// },
 
 export default SURVEY_DATA;


### PR DESCRIPTION
closes https://github.com/codefordenver/expunge-colorado-screener/issues/13
closes https://github.com/codefordenver/expunge-colorado-screener/issues/23

- Fixed logic for chargeToSeal so only one dependency if response is changed
- Updated language to questions and added attemptToSeal question based on client request
- Included triggers in data model to replace questions at the end indicating outcomes so only 1 outcome is returned in data object
- Created Outcome component as a placeholder for content