### PR TITLE
Load cached survey data & add versioning (hashes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "homepage": "https://codefordenver.github.io/expunge-colorado-screener",
   "dependencies": {
+    "jssha": "^3.2.0",
     "node-sass": "4.14.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/App.scss
+++ b/src/App.scss
@@ -6,8 +6,6 @@ $color-dark-purple: rgb(133, 77, 185);
     width: 100vw;
     align-items: center;
     flex-direction: column;
-    .center-me {
-    }
 }
 
 .btn-nav {
@@ -27,6 +25,8 @@ div.header {
 
 div.container {
     background-color: lightblue;
+    padding-bottom: 1em;
+    margin-bottom: 2em;
 }
 
 h1 {

--- a/src/Components/SurveyComponent.js
+++ b/src/Components/SurveyComponent.js
@@ -17,9 +17,9 @@ function SurveyComponent({ surveyModel }) {
     const [outcome, setOutcome] = useState('');
 
     useEffect(() => {
-        surveyModel.currentPageNo = cache?.currentPageNo;
         surveyModel.data = cache?.data;
-    }, [surveyModel]);
+        surveyModel.currentPageNo = cache?.currentPageNo;
+    }, []);
 
     function handleComplete(survey) {
         setOutcome(survey.data.outcome);
@@ -28,6 +28,12 @@ function SurveyComponent({ surveyModel }) {
 
     function persistDataToLocalStorage({ currentPageNo, data }) {
         setCache({ currentPageNo, data });
+    }
+
+    function startOver() {
+        setCache(null);
+        setOutcome(null);
+        surveyModel.clear();
     }
 
     return (
@@ -42,6 +48,9 @@ function SurveyComponent({ surveyModel }) {
             ) : (
                 <Outcome type={outcome} />
             )}
+            <button onClick={startOver} className="btn-nav">
+                Start Over
+            </button>
         </div>
     );
 }

--- a/src/Components/SurveyComponent.js
+++ b/src/Components/SurveyComponent.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as Survey from 'survey-react';
-import SURVEY_DATA from '../data/survey.js';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 
 const myCss = {
@@ -13,26 +12,32 @@ const myCss = {
     container: 'container',
 };
 
-function SurveyComponent() {
-    const [surveyData, setSurveyData] = useLocalStorage('surveyData', null);
+function SurveyComponent({ surveyModel }) {
+    const [cache, setCache] = useLocalStorage('surveyCache', null);
     const [outcome, setOutcome] = useState('');
 
-    function onComplete(survey) {
+    useEffect(() => {
+        surveyModel.currentPageNo = cache?.currentPageNo;
+        surveyModel.data = cache?.data;
+    }, [surveyModel]);
+
+    function handleComplete(survey) {
         setOutcome(survey.data.outcome);
+        setCache(null);
     }
 
-    function persistDataToLocalStorage(survey) {
-        setSurveyData(survey.data);
+    function persistDataToLocalStorage({ currentPageNo, data }) {
+        setCache({ currentPageNo, data });
     }
 
     return (
         <div>
             {!outcome ? (
                 <Survey.Survey
-                    json={SURVEY_DATA}
                     css={myCss}
+                    model={surveyModel}
                     onValueChanged={persistDataToLocalStorage}
-                    onComplete={onComplete}
+                    onComplete={handleComplete}
                 />
             ) : (
                 <Outcome type={outcome} />

--- a/src/Components/SurveyComponent.js
+++ b/src/Components/SurveyComponent.js
@@ -30,10 +30,13 @@ function SurveyComponent({ surveyModel }) {
         setCache({ currentPageNo, data });
     }
 
-    function startOver() {
+    // TODO/fix: if called *after* completing the survey,
+    // all questions on first page are visible (this gets
+    // corrected as soon as you select anything)
+    function reset() {
+        surveyModel.clear();
         setCache(null);
         setOutcome(null);
-        surveyModel.clear();
     }
 
     return (
@@ -48,8 +51,8 @@ function SurveyComponent({ surveyModel }) {
             ) : (
                 <Outcome type={outcome} />
             )}
-            <button onClick={startOver} className="btn-nav">
-                Start Over
+            <button onClick={reset} className="btn-nav">
+                Reset
             </button>
         </div>
     );

--- a/src/Components/SurveyComponent.js
+++ b/src/Components/SurveyComponent.js
@@ -30,9 +30,9 @@ function SurveyComponent({ surveyModel, version }) {
         setCache({ ...cache, currentPageNo, data });
     }
 
-    // TODO/fix: if called *after* completing the survey,
-    // all questions on first page are visible (this gets
-    // corrected as soon as you select anything)
+    /* TODO/fix: if this is called *after* completing the survey,
+       it resets everything except for question visibility on page 0
+       (but corrects itself as soon as you try to select something) */
     function reset() {
         surveyModel.clear();
         setCache(null);

--- a/src/Components/SurveyComponent.js
+++ b/src/Components/SurveyComponent.js
@@ -1,24 +1,24 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import * as Survey from 'survey-react';
-import { useState, useEffect } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 
 const myCss = {
-    matrix: {
-        root: 'table table-striped',
-    },
     navigationButton: 'btn-nav',
     header: 'header',
     container: 'container',
 };
 
-function SurveyComponent({ surveyModel }) {
+function SurveyComponent({ surveyModel, version }) {
     const [cache, setCache] = useLocalStorage('surveyCache', null);
     const [outcome, setOutcome] = useState('');
 
     useEffect(() => {
-        surveyModel.data = cache?.data;
-        surveyModel.currentPageNo = cache?.currentPageNo;
+        if (cache?.version === version) {
+            surveyModel.data = cache.data;
+            surveyModel.currentPageNo = cache.currentPageNo;
+        } else {
+            setCache({ version });
+        }
     }, []);
 
     function handleComplete(survey) {
@@ -27,7 +27,7 @@ function SurveyComponent({ surveyModel }) {
     }
 
     function persistDataToLocalStorage({ currentPageNo, data }) {
-        setCache({ currentPageNo, data });
+        setCache({ ...cache, currentPageNo, data });
     }
 
     // TODO/fix: if called *after* completing the survey,

--- a/src/data/survey.js
+++ b/src/data/survey.js
@@ -1,5 +1,6 @@
 const SURVEY_DATA = {
     title: 'Tell us some more about your case.',
+    clearInvisibleValues: 'onHidden',
     triggers: [
         {
             type: 'setvalue',

--- a/src/data/survey.js
+++ b/src/data/survey.js
@@ -50,14 +50,13 @@ const SURVEY_DATA = {
                     isRequired: true,
                     name: 'federalCase',
                     title: 'Was your case a federal case?',
-                    visibleIf: "{over18} = 'Yes' and {coloradoArrest} = 'Yes'",
+                    visibleIf: "{over18} = 'Yes'",
                 },
             ],
         },
         {
             name: 'sealingArrestsAndCharges',
-            visibleIf:
-                "{coloradoArrest} = 'Yes' and {over18} = 'Yes' and {federalCase} = 'No'",
+            visibleIf: "{federalCase} = 'No'",
             questions: [
                 {
                     type: 'radiogroup',
@@ -92,8 +91,7 @@ const SURVEY_DATA = {
         },
         {
             name: 'convictionRequirements',
-            visibleIf:
-                "{chargeToSeal} = 'Eligible Charge Type' and {chargeDismissedOrAcquitted} = 'No'",
+            visibleIf: "{chargeToSeal} = 'Eligible Charge Type'",
             questions: [
                 {
                     type: 'radiogroup',

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,27 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
+import jsSHA from 'jssha';
 import * as Survey from 'survey-react';
 import SURVEY_DATA from './data/survey.js';
-import SurveyComponent from './components/SurveyComponent';
+import SurveyComponent from './Components/SurveyComponent';
 import './App.scss';
 
 const surveyModel = new Survey.Model(SURVEY_DATA);
+
 // for debugging only
 // window.survey = surveyModel;
+
+// create survey version # by hashing stringified survey data
+const shaObj = new jsSHA('SHA-1', 'TEXT');
+shaObj.update(JSON.stringify(SURVEY_DATA));
+const hash = shaObj.getHash('HEX');
 
 ReactDOM.render(
     <React.StrictMode>
         <div className="app">
             <h1>Expunge Colorado Screener</h1>
             <div className="center-me">
-                <SurveyComponent surveyModel={surveyModel} />
+                <SurveyComponent surveyModel={surveyModel} version={hash} />
             </div>
         </div>
     </React.StrictMode>,

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,11 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import * as Survey from 'survey-react';
 import SURVEY_DATA from './data/survey.js';
-import SurveyComponent from './Components/SurveyComponent';
+import SurveyComponent from './components/SurveyComponent';
 import './App.scss';
 
 const surveyModel = new Survey.Model(SURVEY_DATA);
-// for debugging
+// for debugging only
 // window.survey = surveyModel;
 
 ReactDOM.render(

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import SurveyComponent from './Components/SurveyComponent';
 import './App.scss';
 
 const surveyModel = new Survey.Model(SURVEY_DATA);
+// for debugging
+// window.survey = surveyModel;
 
 ReactDOM.render(
     <React.StrictMode>

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,18 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
+import * as Survey from 'survey-react';
+import SURVEY_DATA from './data/survey.js';
 import SurveyComponent from './Components/SurveyComponent';
 import './App.scss';
+
+const surveyModel = new Survey.Model(SURVEY_DATA);
 
 ReactDOM.render(
     <React.StrictMode>
         <div className="app">
             <h1>Expunge Colorado Screener</h1>
             <div className="center-me">
-                <SurveyComponent />
+                <SurveyComponent surveyModel={surveyModel} />
             </div>
         </div>
     </React.StrictMode>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6859,6 +6859,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jssha@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jssha/-/jssha-3.2.0.tgz#88ec50b866dd1411deaddbe6b3e3692e4c710f16"
+  integrity sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz#642f1d7b88aa6d7eb9d8f2210e166478444fa891"


### PR DESCRIPTION
closes https://github.com/codefordenver/expunge-colorado-screener/issues/17

Could definitely use help testing everything

### How it works

Setting survey model properties
- First we needed a [survey model](https://surveyjs.io/Documentation/Library?id=surveymodel) class instance, in order to mutate the `currentPageNo` and `data` properties. I made one at the root called `surveyModel`, which is passed to `SurveyComponent` -> `Survey.Survey`

- When `SurveyComponent` mounts, check local storage for any relevant* data and if found, update `surveyModel`

*To load or not to load
- We shouldn't load cached responses if the survey structure/questions have changed, so we need a way to tell. One way is to generate a "version number" by hashing the stringified contents of `SURVEY_DATA` using SHA-128 (how Github commit hashes are made). The same content will always produce the same hash, and any slight change will produce a different hash. I used [jsSHA](https://github.com/Caligatio/jsSHA) to compute the hash at the root and pass it to `SurveyComponent`

- When `SurveyComponent` mounts, check if there's a hash in local storage. If it's the same as the currently computed hash, it's safe to load pre-existing data. Otherwise, add the new hash to local storage and clear everything else

### Cascade conditions for `visibleIf`
- Also added [`clearInvisibleValues: 'onHidden'`](https://surveyjs.io/Examples/Library/?id=condition-cascade#content-js) to `SURVEY_DATA`, which means we don't have to check multiple preceding questions, just the one before